### PR TITLE
Upgrade opentracing dependency

### DIFF
--- a/method-tracer.gemspec
+++ b/method-tracer.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
 
-  spec.add_dependency 'opentracing', '~> 0.3.1'
+  spec.add_dependency 'opentracing', '~> 0.5.0'
 
   spec.add_development_dependency "tracing-matchers", "~> 1.0"
   spec.add_development_dependency "bundler", "~> 1.15"


### PR DESCRIPTION
In the same spirit as https://github.com/iaintshine/ruby-grpc-opentracing/pull/6, this upgrades the `opentracing` dependency.